### PR TITLE
WIP: Better help for -m option and python2/3 interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ using the GitLab API.
 
 ## Requirements
 - [`python-gitlab`] - As of at least [d4a24a5c4d], which is currently unreleased.
+- [`python-dateutil`] - A robust ISO-8601 timestamp parser, among other things
+- [`pytz`] - Because Python 2.7 has no tz info
 
 ## Usage
 This script leverages the [`python-gitlab` config file][python-gitlab-config].

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ using the GitLab API.
 ## Requirements
 - [`python-gitlab`] - As of at least [d4a24a5c4d], which is currently unreleased.
 - [`python-dateutil`] - A robust ISO-8601 timestamp parser, among other things
-- [`pytz`] - Because Python 2.7 has no tz info
+- [`pytz`] - Timezone info (if you are using python2)
 
 ## Usage
 This script leverages the [`python-gitlab` config file][python-gitlab-config].

--- a/gitlab-artifact-cleanup
+++ b/gitlab-artifact-cleanup
@@ -1,7 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from dateutil.parser import parse as parse_datetime
 from gitlab import Gitlab
 from gitlab.exceptions import *
 
@@ -21,7 +22,7 @@ class GitlabArtifactCleanup(object):
 
         subtotal_size = 0
         subtotal_count = 0
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         for build in proj.builds.list(all=True):
             try:
@@ -38,7 +39,7 @@ class GitlabArtifactCleanup(object):
                 continue
 
             # Skip builds that are too recent
-            ts = datetime.strptime(build.created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+            ts = parse_datetime(build.created_at)
             age = now - ts
             if age < self.min_age:
                 print('Skipping, too recent')

--- a/gitlab-artifact-cleanup
+++ b/gitlab-artifact-cleanup
@@ -1,11 +1,25 @@
 #!/usr/bin/env python
 from __future__ import print_function
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta 
+
+#if this was in python3, we could do from datetime import timezone
+import pytz # python 2 sucks for timezones, you need to pip install pytz
+
+import dateutil.parser
 from gitlab import Gitlab
 from gitlab.exceptions import *
 
 __version__ = '0.2.0'
+
+# Python3:
+#def utcnow():
+#   return datetime.now(timezone.utc) # versus datetime.utcnow()
+
+# Python2:
+def utcnow():
+   return datetime.utcnow().replace(tzinfo=pytz.utc)
+
 
 class GitlabArtifactCleanup(object):
     def __init__(self, dry_run=False, min_age=None):
@@ -15,13 +29,22 @@ class GitlabArtifactCleanup(object):
         self.total_size = 0
         self.total_count = 0
 
-
+    def parse_timestamp(self, astr):
+        """ Parse string get a timestamp that is timezone aware """
+        ts = 0
+	try:
+	   ts = dateutil.parser.parse(astr)
+	except:
+	   print("Unable to parse ISO-8601 datetime: "+repr(astr)+" ?")
+	   raise
+	return ts	
+	
     def cleanup_project(self, proj):
         print(proj.name_with_namespace)
 
         subtotal_size = 0
         subtotal_count = 0
-        now = datetime.utcnow()
+        now = utcnow() # datetime.utcnow()
 
         for build in proj.builds.list(all=True):
             try:
@@ -38,8 +61,8 @@ class GitlabArtifactCleanup(object):
                 continue
 
             # Skip builds that are too recent
-            ts = datetime.strptime(build.created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
-            age = now - ts
+            ts = self.parse_timestamp(build.created_at) 
+            age = now - ts # both or neither of these must contain timezones
             if age < self.min_age:
                 print('Skipping, too recent')
                 continue
@@ -50,7 +73,7 @@ class GitlabArtifactCleanup(object):
                 ))
 
             if not self.dry_run:
-                build.erase()
+                build.delete() # used to be erase?
 
             subtotal_size += af['size']
             self.total_size += af['size']

--- a/gitlab-artifact-cleanup
+++ b/gitlab-artifact-cleanup
@@ -1,7 +1,21 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 from __future__ import print_function
 import argparse
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+
+
+try:
+    # python3 only
+    from datetime import timezone
+    def utcnow():
+       return datetime.now(timezone.utc)    
+except:
+    # python2 fallback.
+    import pytz
+    def utcnow():
+       return datetime.utcnow().replace(tzinfo=pytz.utc)
+    
+
 from dateutil.parser import parse as parse_datetime
 from gitlab import Gitlab
 from gitlab.exceptions import *
@@ -10,11 +24,7 @@ __version__ = '0.2.0'
 
 # Python2:
 # import pytz
-#def utcnow():
-#   return datetime.utcnow().replace(tzinfo=pytz.utc)
 
-def utcnow():
-   return datetime.now(timezone.utc)
 
 class GitlabArtifactCleanup(object):
     def __init__(self, dry_run=False, min_age=None):

--- a/gitlab-artifact-cleanup
+++ b/gitlab-artifact-cleanup
@@ -22,8 +22,7 @@ from gitlab.exceptions import *
 
 __version__ = '0.2.0'
 
-# Python2:
-# import pytz
+
 
 
 class GitlabArtifactCleanup(object):
@@ -127,11 +126,9 @@ def parse_args():
             help='Cleanup artifacts for all accessible projects')
     ap.add_argument('-m', '--min-age', type=parse_timedelta, default=timedelta(),
             help='Minimum age for artifacts to be deleted;\n'
-                 'e.g. "172800"\n'
-                 '  == "172800 seconds"\n'
-                 '  == "2880 minutes"\n'
-                 '  == "48 hours"\n'
-                 '  == "2 days"')
+                 '  -m \'30 days\'     : 30 days \n'
+                 '  -m \'8 hours\'     : 8 hours \n'
+                 '  -m 60            : 60 seconds \n' )
     ap.add_argument('-n', '--dry-run', action='store_true',
             help="Don't actually delete anything")
     ap.add_argument('-p', '--project', dest='projects', action='append',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-gitlab
+dateutil


### PR DESCRIPTION
Apologies for mixing two concerns in one MR/branch here...     Still getting the hang of this.

Two changes here:
1.  Reinstate pytz when python3 only module fails to import
2.  Friendlier (in my humble opinion) help for -m

```
 -m MIN_AGE, --min-age MIN_AGE
                        Minimum age for artifacts to be deleted;
                          -m '30 days'     : 30 days
                          -m '8 hours'     : 8 hours
                          -m 60            : 60 seconds
```
