### PR TITLE
Add Python 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ using the GitLab API.
 
 ## Requirements
 - [`python-gitlab`] - As of at least [d4a24a5c4d], which is currently unreleased.
+- [`python-dateutil`] - A robust ISO-8601 timestamp parser, among other things
+- [`pytz`] - Timezone info (if you are using python2)
 
 ## Usage
 This script leverages the [`python-gitlab` config file][python-gitlab-config].

--- a/gitlab-artifact-cleanup
+++ b/gitlab-artifact-cleanup
@@ -1,7 +1,21 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 from __future__ import print_function
 import argparse
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+
+
+try:
+    # python3 only
+    from datetime import timezone
+    def utcnow():
+       return datetime.now(timezone.utc)    
+except:
+    # python2 fallback.
+    import pytz
+    def utcnow():
+       return datetime.utcnow().replace(tzinfo=pytz.utc)
+    
+
 from dateutil.parser import parse as parse_datetime
 from gitlab import Gitlab
 from gitlab.exceptions import *
@@ -22,7 +36,7 @@ class GitlabArtifactCleanup(object):
 
         subtotal_size = 0
         subtotal_count = 0
-        now = datetime.now(timezone.utc)
+        now = utcnow()
 
         for build in proj.builds.list(all=True):
             try:

--- a/gitlab-artifact-cleanup
+++ b/gitlab-artifact-cleanup
@@ -1,26 +1,29 @@
 #!/usr/bin/env python
 from __future__ import print_function
+import sys
 import argparse
 from datetime import datetime, timedelta
+from dateutil.parser import parse as parse_datetime
+from gitlab import Gitlab
+from gitlab.exceptions import *
 
+__version__ = '0.2.0'
 
 try:
     # python3 only
     from datetime import timezone
     def utcnow():
        return datetime.now(timezone.utc)    
-except:
+except ImportError:
     # python2 fallback.
-    import pytz
+    try:
+        import pytz
+    except ImportError:
+        print("gitlab-artifact-cleanup requires either Python 3 or the pytz package")
+        sys.exit(2)
     def utcnow():
        return datetime.utcnow().replace(tzinfo=pytz.utc)
     
-
-from dateutil.parser import parse as parse_datetime
-from gitlab import Gitlab
-from gitlab.exceptions import *
-
-__version__ = '0.2.0'
 
 class GitlabArtifactCleanup(object):
     def __init__(self, dry_run=False, min_age=None):


### PR DESCRIPTION
We switched to Python 3 only because of its `datetime.timezone` class. This restores support for Python 2, by trying to use `pytz` for the UTC timezone.
